### PR TITLE
updating workflow dependency to use 'update_branch_release' 

### DIFF
--- a/.github/workflows/tag_on_merge.yml
+++ b/.github/workflows/tag_on_merge.yml
@@ -171,7 +171,7 @@ jobs:
         prune: true
 
   build-min-js:
-    needs: publish_release
+    needs: update_branch_release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
updating workflow dependency to use 'update_branch_release' instead of 'publish release'