### PR TITLE
Update workflow dependency

### DIFF
--- a/.github/workflows/tag_on_merge.yml
+++ b/.github/workflows/tag_on_merge.yml
@@ -142,7 +142,7 @@ jobs:
             }
 
   update_branch_release:
-    needs: publish_release
+    needs: build-min-js
     if: contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     steps:
@@ -171,7 +171,7 @@ jobs:
         prune: true
 
   build-min-js:
-    needs: update_branch_release
+    needs: publish_release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Update workflow dependency to use 'update_branch_release' instead of 'publish release'