### PR TITLE
Update workflow dependency to use 'update_branch_release' instead of 'publish release'

### DIFF
--- a/.github/workflows/tag_on_merge.yml
+++ b/.github/workflows/tag_on_merge.yml
@@ -171,7 +171,7 @@ jobs:
         prune: true
 
   build-min-js:
-    needs: update_release_draft
+    needs: publish_release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Update workflow dependency to use 'update_branch_release' instead of 'publish release'