### PR TITLE
Update workflow dependency to use 'build-min-js' instead of 'publish release'

### DIFF
--- a/.github/workflows/tag_on_merge.yml
+++ b/.github/workflows/tag_on_merge.yml
@@ -142,7 +142,7 @@ jobs:
             }
 
   update_branch_release:
-    needs: publish_release
+    needs: build-min-js
     if: contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Update workflow dependency to use 'build-min-js' instead of 'publish release'